### PR TITLE
Improved coding style

### DIFF
--- a/settings_pagelist.php
+++ b/settings_pagelist.php
@@ -29,7 +29,7 @@ require(__DIR__ . '/../../config.php');
 require_once($CFG->libdir.'/adminlib.php');
 
 // Include lib.php.
-require_once(__DIR__ . '/lib.php');
+require_once($CFG->dirroot . '/local/staticpage/lib.php');
 
 global $CFG, $PAGE, $OUTPUT;
 

--- a/view.php
+++ b/view.php
@@ -30,7 +30,8 @@ require(__DIR__ . '/../../config.php');
 // @codingStandardsIgnoreEnd
 
 // Include lib.php.
-require_once(__DIR__ . '/lib.php');
+require_once($CFG->dirroot . '/local/staticpage/lib.php');
+
 
 // Globals.
 global $PAGE;

--- a/view.php
+++ b/view.php
@@ -92,8 +92,17 @@ if ($localstaticpageconfig->apacherewrite == true) {
 }
 
 // Set page context.
-$PAGE->set_context(context_system::instance());
 
+// Set page context.
+// abertranb allow set course context
+//$PAGE->set_context(context_system::instance());
+
+$course_id = optional_param('course_id',0, PARAM_INT);
+if ($course_id > 0) {
+    $PAGE->set_context( context_course::instance($course_id) );
+} else {
+    $PAGE->set_context( context_system::instance() );
+}
 // Set page layout.
 $PAGE->set_pagelayout('standard');
 


### PR DESCRIPTION
Hi from https://docs.moodle.org/dev/Coding_style#Require_.2F_include 
Any other include/require should use a path starting with __DIR__ or an absolute path starting with $CFG->dirroot or $CFG->libdir. Relative includes starting with "../" can sometimes behave strangely under PHP, so should not be used. Our CLI scripts must not use relative config.php paths starting with "../".

We tested as a customscripts and fails, then changing that we can overwrite views

Best regards